### PR TITLE
WIP: Add new fields to a web_directory

### DIFF
--- a/web_directory.go
+++ b/web_directory.go
@@ -3,12 +3,19 @@ package lair
 // WebDirectory is a path from a web listener and is a child
 // of a Host. Port is not a relationship to a Service.
 type WebDirectory struct {
-	ID             string `json:"_id" bson:"_id"`
-	ProjectID      string `json:"projectId" bson:"projectId"`
-	HostID         string `json:"hostId" bson:"hostId"`
-	Path           string `json:"path" bson:"path"`
-	Port           int    `json:"port" bson:"port"`
-	ResponseCode   string `json:"responseCode" bson:"responseCode"`
-	LastModifiedBy string `json:"lastModifiedBy" bson:"lastModifiedBy"`
-	IsFlagged      bool   `json:"isFlagged" bson:"isFlagged"`
+	HostID           string `json:"hostId" bson:"hostId"`
+	ID               string `json:"_id" bson:"_id"`
+	IsFlagged        bool   `json:"isFlagged" bson:"isFlagged"`
+	LastModifiedBy   string `json:"lastModifiedBy" bson:"lastModifiedBy"`
+	Path             string `json:"path" bson:"path"`
+	Port             int    `json:"port" bson:"port"`
+	ProjectID        string `json:"projectId" bson:"projectId"`
+	RequestData      string `json:"requestData,omitempty" bson:"requestData,omitempty"`
+	RequestHeaders   string `json:"requestHeaders,omitempty" bson:"requestHeaders,omitempty"`
+	RequestMethod    string `json:"requestMethod,omitempty" bson:"requestMethod,omitempty"`
+	RequestProtocol  string `json:"requestProtocol,omitempty" bson:"requestProtocol,omitempty"`
+	ResponseBody     string `json:"responseBody,omitempty" bson:"responseBody,omitempty"`
+	ResponseCode     string `json:"responseCode" bson:"responseCode"`
+	ResponseLength   uint32 `json:"responseLength,omitempty" bson:"responseLength,omitempty"`
+	ResponseLocation string `json:"responseLocation,omitempty" bson:"responseLocation,omitempty"`
 }


### PR DESCRIPTION
This PR is an attempt to solve #1 

Due to the number of projects that will require a change to properly incorporate this (_go-lair, lair, pylair, api-server_) I suppose that the model should be discussed first (and is it worth it actually).

To fit the needs to store web pentest data I added the following fields:
* RequestData
* RequestHeaders
* RequestMethod
* RequestProtocol
* ResponseData
* ResponseHeaders
* ResponseLength
* ResponseLocation

All keys in the struct are sorted alphabetically now.

Not sure if we should add fuzzed request parameter/value here too and probably I missed something else, so any feedback is appreciated.